### PR TITLE
Per-buffer folding styles and explicit folding on triple-braces.

### DIFF
--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -47,7 +47,8 @@
     (python-mode           . origami-indent-parser)
     (emacs-lisp-mode       . origami-elisp-parser)
     (lisp-interaction-mode . origami-elisp-parser)
-    (clojure-mode          . origami-clj-parser))
+    (clojure-mode          . origami-clj-parser)
+    (triple-braces         . origami-triple-braces-parser))
   "alist mapping major-mode to parser function."
   :type 'hook
   :group 'origami)
@@ -216,6 +217,11 @@ position in the CONTENT."
 
 (defun origami-clj-parser (create)
   (origami-lisp-parser create "(def\\(\\w\\|-\\)*\\s-*\\(\\s_\\|\\w\\|[?!]\\)*\\([ \\t]*\\[.*?\\]\\)?"))
+
+(defun origami-triple-braces-parser (create)
+  (lambda (content)
+    (let ((positions (origami-get-positions content "{{{\\|}}}")))
+      (origami-build-pair-tree create "{{{" "}}}" positions))))
 
 (provide 'origami-parsers)
 

--- a/origami.el
+++ b/origami.el
@@ -380,7 +380,9 @@ was last built."
                                                 -last-item
                                                 origami-fold-data)
                                             (origami-create-overlay beg end offset buffer)))))))
-    (-when-let (parser-gen (or (cdr (assoc (buffer-local-value 'major-mode buffer)
+    (-when-let (parser-gen (or (cdr (assoc (if (local-variable-p 'origami-fold-style)
+                                               (buffer-local-value 'origami-fold-style buffer)
+                                             (buffer-local-value 'major-mode buffer))
                                            origami-parser-alist))
                                'origami-indent-parser))
       (funcall parser-gen create))))


### PR DESCRIPTION
My feeble attempt to add folding based on explicit markers (`{{{ ... }}}`).

Also added support for setting folding style per buffer. Now you can do something like:

    ;; -*- origami-fold-style: triple-braces -*-

Which will use the parser from the `triple-braces` entry in `origami-parser-alist`.

I'm sure there is a much more elegant way of implementing it. But, well, it seems to work anyway.