### PR TITLE
Add c-macro parser to c++-mode too

### DIFF
--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -243,7 +243,7 @@ position in the CONTENT."
 (defcustom origami-parser-alist
   `((java-mode             . origami-java-parser)
     (c-mode                . origami-c-parser)
-    (c++-mode              . origami-c-style-parser)
+    (c++-mode              . origami-c-parser)
     (perl-mode             . origami-c-style-parser)
     (cperl-mode            . origami-c-style-parser)
     (js-mode               . origami-c-style-parser)


### PR DESCRIPTION
This is a good to have to macros in C++ code as well. Should be okay since the c-macros are similar for `c-mode` and `c++-mode` 
