### PR TITLE
Avoid "Match data clobbered by buffer modification hooks" error

### DIFF
--- a/origami.el
+++ b/origami.el
@@ -82,12 +82,15 @@ header overlay should cover. Result is a cons cell of (begin . end)."
            ;; Find the end of the folded region -- include the following
            ;; newline if possible. The header will span the entire fold.
            (save-excursion
-             (goto-char (overlay-end fold-overlay))
-             (when (looking-at ".")
-               (forward-char 1)
-               (when (looking-at "\n")
-                 (forward-char 1)))
-             (point))))
+             (save-match-data
+               (goto-char (overlay-end fold-overlay))
+               (when (looking-at ".")
+                 (forward-char 1)
+                 (when (looking-at "\n")
+                   (forward-char 1)))
+               (point))
+             )
+           ))
       (cons fold-begin fold-end))))
 
 (defun origami-header-overlay-reset-position (header-overlay)


### PR DESCRIPTION
I found a reliable reproduction scenario and a code change that fixes #56 for me.

Reproduction scenario:

1. Visit a C++ file that contains a syntax error.  (Presumably the programming language is not important.)
2. Do `revert-buffer`.  This is a **workaround** for the issue, so we get to a state where query-replace works.
3. Do a `query-replace` that replaces multiple occurrences.  This succeeds.
4. Undo the replacement.
5. Do `compile`.  The syntax error is reported.
6. Do `next-error` to move to the (first) syntax error.
7. Do a `query-replace` that replaces multiple occurrences.  Only the first occurrence is replaced, and the error message "Match data clobbered by buffer modification hooks" is generated.  This reproduces the problem.

The **fix** that works for me is to edit function `origami-header-overlay-range` in origami.el by wrapping the body of the `save-excursion` call in a `save-match-data` call, yielding

           (save-excursion
             (save-match-data
               (goto-char (overlay-end fold-overlay))
               (when (looking-at ".")
                 (forward-char 1)
                 (when (looking-at "\n")
                   (forward-char 1)))
               (point))
