### PR TITLE
Fix broken defface in custom

### DIFF
--- a/origami.el
+++ b/origami.el
@@ -65,7 +65,7 @@
   "Face used to display fringe contents.")
 
 (defface origami-fold-replacement-face
-  '((t :inherit 'font-lock-comment-face))
+  `((t :inherit ,font-lock-comment-face))
   "Face used to display the fold replacement text.")
 
 ;;; overlay manipulation


### PR DESCRIPTION
Currently this defface value shows up as a lisp expression, this PR changes it back to the regular point and click customize face interface.