### PR TITLE
Using `cl-lib` because `cl` is deprecated

### DIFF
--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -30,7 +30,7 @@
 ;;; Commentary:
 
 ;;; Code:
-(require 'cl)
+(require 'cl-lib)
 (require 'dash)
 
 (defun origami-get-positions (content regex)


### PR DESCRIPTION
Using `cl-lib` instead of `cl`.
 * `origami.el` already uses `cl-lib`.
 * `emacs-27` marked `cl` package as *deprecated*.