### PR TITLE
Require cl-lib instead of cl

### DIFF
--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -30,7 +30,7 @@
 ;;; Commentary:
 
 ;;; Code:
-(require 'cl)
+(require 'cl-lib)
 (require 'dash)
 
 (defun origami-get-positions (content regex)


### PR DESCRIPTION
cl is deprecated as of Emacs 27


----

#