### PR TITLE
Update origami-parsers.el

### DIFF
--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -30,7 +30,7 @@
 ;;; Commentary:
 
 ;;; Code:
-(require 'cl)
+(require 'cl-lib)
 (require 'dash)
 
 (defun origami-get-positions (content regex)


### PR DESCRIPTION
Using `cl-lib` instead of `cl`. 
additional "Package cl is deprecated" fix