### PR TITLE
Extend elisp parser regexp to understand cl-*

### DIFF
--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -228,7 +228,7 @@ position in the CONTENT."
         (reverse acc)))))
 
 (defun origami-elisp-parser (create)
-  (origami-lisp-parser create "(def\\w*\\s-*\\(\\s_\\|\\w\\|[:?!]\\)*\\([ \\t]*(.*?)\\)?"))
+  (origami-lisp-parser create "(\\(?:cl-\\)?def\\w*\\s-*\\(\\s_\\|\\w\\|[:?!]\\)*\\([ \\t]*(.*?)\\)?"))
 
 (defun origami-clj-parser (create)
   (origami-lisp-parser create "(def\\(\\w\\|-\\)*\\s-*\\(\\s_\\|\\w\\|[?!]\\)*\\([ \\t]*\\[.*?\\]\\)?"))


### PR DESCRIPTION
I introduced a shy group in the elisp parser's regexp to allow for cl-defun, cl-defmacro, ...

And thanks for this nice package!