### PR TITLE
Fix byte-compiler warnings of calls to deprecated functions or missing declarations.

### DIFF
--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -228,7 +228,7 @@ position in the CONTENT."
         (reverse acc)))))
 
 (defun origami-elisp-parser (create)
-  (origami-lisp-parser create "(def\\w*\\s-*\\(\\s_\\|\\w\\|[:?!]\\)*\\([ \\t]*(.*?)\\)?"))
+  (origami-lisp-parser create "(\\(?:cl-\\)?def\\w*\\s-*\\(\\s_\\|\\w\\|[:?!]\\)*\\([ \\t]*(.*?)\\)?"))
 
 (defun origami-clj-parser (create)
   (origami-lisp-parser create "(def\\(\\w\\|-\\)*\\s-*\\(\\s_\\|\\w\\|[?!]\\)*\\([ \\t]*\\[.*?\\]\\)?"))

--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -32,6 +32,14 @@
 ;;; Code:
 (require 'cl-lib)
 (require 'dash)
+(require 's)
+
+;; The following prevent end-of-data byte-compiler warnings:
+;; these functions are defined in origami.el but can require origami
+;; because origami already requires origami-parsers.
+(declare-function origami-fold-children "origami")
+(declare-function origami-fold-shallow-merge "origami")
+(declare-function origami-fold-root-node "origami")
 
 (defun origami-get-positions (content regex)
   "Returns a list of positions where REGEX matches in CONTENT. A
@@ -206,6 +214,7 @@ position in the CONTENT."
 			      acc))
 	      (goto-char new-end)))
 	  acc))
+      (declare-function python-subparser "origami-parsers") ; prevent byte-compiler warning
       (python-subparser (point-min) (point-max)))))
 
 (defun origami-lisp-parser (create regex)

--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -30,7 +30,7 @@
 ;;; Commentary:
 
 ;;; Code:
-(require 'cl)
+(require 'cl-lib)
 (require 'dash)
 
 (defun origami-get-positions (content regex)
@@ -95,7 +95,7 @@ position in the CONTENT."
                              ;; complexity here is due to having to find the end of the children so that the
                              ;; parent encompasses them
                              (-reduce-r-from (lambda (nodes acc)
-                                               (destructuring-bind (children-end . children) (build-nodes (cdr nodes))
+                                               (cl-destructuring-bind (children-end . children) (build-nodes (cdr nodes))
                                                  (let ((this-end (max children-end (end (car nodes)))))
                                                    (cons (max this-end (car acc))
                                                          (cons (funcall create
@@ -156,13 +156,13 @@ position in the CONTENT."
 (defun origami-c-style-parser (create)
   (lambda (content)
     (let ((positions (->> (origami-get-positions content "[{}]")
-                          (remove-if (lambda (position)
-                                       (let ((face (get-text-property 0 'face (car position))))
-                                         (-any? (lambda (f)
-                                                  (memq f '(font-lock-doc-face
-                                                            font-lock-comment-face
-                                                            font-lock-string-face)))
-                                                (if (listp face) face (list face)))))))))
+                          (cl-remove-if (lambda (position)
+                                          (let ((face (get-text-property 0 'face (car position))))
+                                            (-any? (lambda (f)
+                                                     (memq f '(font-lock-doc-face
+                                                               font-lock-comment-face
+                                                               font-lock-string-face)))
+                                                   (if (listp face) face (list face)))))))))
       (origami-build-pair-tree create "{" "}" positions))))
 
 (defun origami-c-macro-parser (create)

--- a/origami.el
+++ b/origami.el
@@ -273,7 +273,7 @@ header overlay should cover. Result is a cons cell of (begin . end)."
 F applied to the leaf."
   (cdr
    (-reduce-r-from (lambda (node acc)
-                     (destructuring-bind (old-node . new-node) acc
+                     (cl-destructuring-bind (old-node . new-node) acc
                        (cons node (origami-fold-replace-child node old-node new-node))))
                    (let ((leaf (-last-item path))) (cons leaf (funcall f leaf)))
                    (butlast path))))

--- a/origami.el
+++ b/origami.el
@@ -95,7 +95,7 @@ header overlay should cover. Result is a cons cell of (begin . end)."
     (let ((range (origami-header-overlay-range fold-ov)))
       (move-overlay header-overlay (car range) (cdr range)))))
 
-(defun origami-header-modify-hook (header-overlay after-p b e &optional l)
+(defun origami-header-modify-hook (header-overlay after-p _b _e &optional _l)
   (if after-p (origami-header-overlay-reset-position header-overlay)))
 
 (defun origami-create-overlay (beg end offset buffer)
@@ -157,7 +157,7 @@ header overlay should cover. Result is a cons cell of (begin . end)."
   (overlay-put ov 'before-string nil)
   (overlay-put ov 'after-string nil))
 
-(defun origami-isearch-show (ov)
+(defun origami-isearch-show (_ov)
   (origami-show-node (current-buffer) (point)))
 
 (defun origami-hide-overlay-from-fold-tree-fn (node)
@@ -432,6 +432,12 @@ with the current state and the current node at each iteration."
 
 ;;; interactive utils
 
+;; The following defvar prevent byte compiler warnings.
+;; It would be better to replace the code with defvar-local forms
+;; but that was introduced in Emacs 24.3 and this package supports Emacs 24.
+(defvar origami-history)   ; prevent byte-compiler warning
+(defvar origami-tree-tick) ; prevent byte-compiler warning
+
 (defun origami-setup-local-vars (buffer)
   (with-current-buffer buffer
     (set (make-local-variable 'origami-history)
@@ -491,6 +497,8 @@ was last built."
                                'origami-indent-parser))
       (funcall parser-gen create))))
 
+(defvar origami-mode)                   ; forward declaration to prevent byte-compiler warning
+
 (defun origami-get-fold-tree (buffer)
   "Facade. Build the tree if it hasn't already been built
 otherwise fetch cached tree."
@@ -499,7 +507,7 @@ otherwise fetch cached tree."
         (origami-build-tree buffer (origami-get-parser buffer))
       (origami-get-cached-tree buffer))))
 
-(defun origami-apply-new-tree (buffer old-tree new-tree)
+(defun origami-apply-new-tree (_buffer old-tree new-tree)
   (when new-tree
     (origami-fold-diff old-tree new-tree
                        'origami-hide-overlay-from-fold-tree-fn

--- a/origami.el
+++ b/origami.el
@@ -810,7 +810,7 @@ Lastly, the normal hook `origami-mode-hook' is run using
 Key bindings:
 \\{origami-mode-map}"
   :group 'origami
-  :lighter nil
+  :lighter ""
   :keymap origami-mode-map
   :init-value nil
   (if origami-mode


### PR DESCRIPTION
In my repo I have also merge the work from others that fixed some of the warnings (but not all). And the addition of cl- forms for Emacs Lisp.  