### PR TITLE
Create origami-parsers.el

### DIFF
--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -199,7 +199,7 @@ position in the CONTENT."
 	  ;; iterate all same level children.
 	  (while (and (beginning-of-defun -1) (<= (point) end)) ;; have children between beg and end?
 	    (let* ((new-beg (point))
-		   (new-offset (progn (search-forward-regexp ":" nil t) (- (point) new-beg)))
+		   (new-offset (progn (search-forward-regexp ":$" nil t) (- (point) new-beg)))
 		   (new-end (progn (end-of-defun) (point))))
 	      (setq acc (cons (funcall create new-beg new-end new-offset
 				       (python-subparser new-beg new-end))


### PR DESCRIPTION
Currently, in Python, when we have type-hints in the definition of a function, the folding occurs on the first colon.

Folding the following function:
```
def some_function(arg: ArgType) -> ReturnType:
    # Stuff
    pass
```
will result in only showing
`def some_function(arg:...`

Just updating the rule of the parser to check if the colon is at the end of the line fixes the issue, allowing to show the full function definition, `def some_function(arg: ArgType) -> ReturnType:` which is far more appreciable in my opinion. 
I believe the only cases in Python where we have a colon that is not at the end of the line is the situation described above, where we are hinting the type of a parameter, and the definition of entries in a dictionary, so this modification should not break anything (but I might be mistaken).
The only case I could think of that breaks this is if we add a comment after the colon at the end of the line, but I don't think this really causes an issue.