### PR TITLE
Fix deprecated cl

### DIFF
--- a/origami-parsers.el
+++ b/origami-parsers.el
@@ -30,7 +30,7 @@
 ;;; Commentary:
 
 ;;; Code:
-(require 'cl)
+(require 'cl-lib)
 (require 'dash)
 
 (defun origami-get-positions (content regex)


### PR DESCRIPTION
The `cl` is deprecated, go with `cl-lib`.